### PR TITLE
Added option to use a custom key id for disk encryption set

### DIFF
--- a/disk_encryption_sets.tf
+++ b/disk_encryption_sets.tf
@@ -8,9 +8,8 @@ module "disk_encryption_sets" {
   location            = can(local.global_settings.regions[each.value.region]) ? local.global_settings.regions[each.value.region] : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].location
   resource_group_name = can(each.value.resource_group.name) || can(each.value.resource_group_name) ? try(each.value.resource_group.name, each.value.resource_group_name) : local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group_key, each.value.resource_group.key)].name
   base_tags           = try(local.global_settings.inherit_tags, false) ? try(local.combined_objects_resource_groups[try(each.value.resource_group.lz_key, local.client_config.landingzone_key)][try(each.value.resource_group.key, each.value.resource_group_key)].tags, {}) : {}
-  key_vault_key_id    = local.combined_objects_keyvault_keys[try(each.value.keyvault_key.lz_key, local.client_config.landingzone_key)][try(each.value.key_vault_key_key, each.value.key_vault_key.key)].id
-  keyvault_id         = local.combined_objects_keyvaults[try(each.value.keyvault.lz_key, local.client_config.landingzone_key)][each.value.keyvault.key].id
-}
+  key_vault_key_id    = try(each.value.key_vault_key_id, local.combined_objects_keyvault_keys[try(each.value.keyvault_key.lz_key, local.client_config.landingzone_key)][try(each.value.key_vault_key_key, each.value.key_vault_key.key)].id)
+  keyvault_id         = try(each.value.key_vault_key_id, null) == null ? local.combined_objects_keyvaults[try(each.value.keyvault.lz_key, local.client_config.landingzone_key)][each.value.keyvault.key].id : null}
 
 output "disk_encryption_sets" {
   value = module.disk_encryption_sets

--- a/modules/security/disk_encryption_set/keyvault_policy.tf
+++ b/modules/security/disk_encryption_set/keyvault_policy.tf
@@ -1,4 +1,5 @@
 resource "azurerm_key_vault_access_policy" "des" {
+  count        = try(var.keyvault_id, null) == null ? 0 : 1
   key_vault_id = var.keyvault_id
 
   tenant_id = azurerm_disk_encryption_set.encryption_set.identity.0.tenant_id


### PR DESCRIPTION
## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have added example(s) inside the [./examples/] folder
- [ ] I have added the example(s) to the integration test list for [normal (~30 minutes)](./workflows/standalone-scenarios.json) or [long runner >30 minutes](./workflows/standalone-scenarios-longrunners.json)
- [x] I have checked the [coding conventions as per the wiki](https://github.com/aztfmod/terraform-azurerm-caf/wiki)
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Added option to directly use a custom key id for disk encryption set.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
```
disk_encryption_sets = {
  set1 = {
    name               = "DSE001"
    resource_group_key = "dse"
    key_vault_key_id   = "https://keyvault001.vault.azure.net/keys/dse-cmk/fec2d7f7b8014cf0980551ce30dfec57"
  }
}
```
